### PR TITLE
Добавлена поддержка нескольких стартовых диалогов у НПС

### DIFF
--- a/src/xrGame/AI_PhraseDialogManager.cpp
+++ b/src/xrGame/AI_PhraseDialogManager.cpp
@@ -13,7 +13,11 @@
 #include "gameobject.h"
 #include "relation_registry.h"
 
-CAI_PhraseDialogManager::CAI_PhraseDialogManager(void) { m_sStartDialog = m_sDefaultStartDialog = NULL; }
+CAI_PhraseDialogManager::CAI_PhraseDialogManager(void)
+{
+    m_sStartDialog.clear();
+    m_sDefaultStartDialog.clear();
+}
 CAI_PhraseDialogManager::~CAI_PhraseDialogManager(void) {}
 // PhraseDialogManager
 void CAI_PhraseDialogManager::ReceivePhrase(DIALOG_SHARED_PTR& phrase_dialog)
@@ -70,16 +74,31 @@ void CAI_PhraseDialogManager::AnswerPhrase(DIALOG_SHARED_PTR& phrase_dialog)
     }
 }
 
-void CAI_PhraseDialogManager::SetStartDialog(shared_str phrase_dialog) { m_sStartDialog = phrase_dialog; }
-void CAI_PhraseDialogManager::SetDefaultStartDialog(shared_str phrase_dialog) { m_sDefaultStartDialog = phrase_dialog; }
+void CAI_PhraseDialogManager::SetStartDialog(const DIALOG_ID_VECTOR& phrase_dialog)
+{
+    m_sStartDialog = phrase_dialog;
+}
+
+void CAI_PhraseDialogManager::SetStartDialog(const shared_str& phrase_dialog)
+{
+    m_sStartDialog.emplace(m_sStartDialog.begin(), phrase_dialog);
+}
+
+void CAI_PhraseDialogManager::SetDefaultStartDialog(const DIALOG_ID_VECTOR& phrase_dialog)
+{
+    m_sDefaultStartDialog = phrase_dialog;
+}
 void CAI_PhraseDialogManager::RestoreDefaultStartDialog() { m_sStartDialog = m_sDefaultStartDialog; }
 void CAI_PhraseDialogManager::UpdateAvailableDialogs(CPhraseDialogManager* partner)
 {
     m_AvailableDialogs.clear();
     m_CheckedDialogs.clear();
 
-    if (*m_sStartDialog)
-        inherited::AddAvailableDialog(*m_sStartDialog, partner);
+    for (auto& Dialog : m_sStartDialog)
+    {
+        inherited::AddAvailableDialog(*Dialog, partner);
+    }
+
     inherited::AddAvailableDialog("hello_dialog", partner);
 
     inherited::UpdateAvailableDialogs(partner);

--- a/src/xrGame/AI_PhraseDialogManager.h
+++ b/src/xrGame/AI_PhraseDialogManager.h
@@ -21,16 +21,17 @@ public:
     virtual void UpdateAvailableDialogs(CPhraseDialogManager* partner);
     virtual void AnswerPhrase(DIALOG_SHARED_PTR& phrase_dialog);
 
-    virtual void SetStartDialog(shared_str phrase_dialog);
-    virtual void SetDefaultStartDialog(shared_str phrase_dialog);
-    virtual shared_str GetStartDialog() { return m_sStartDialog; }
+    virtual void SetStartDialog(const DIALOG_ID_VECTOR& phrase_dialog);
+    virtual void SetStartDialog(const shared_str& phrase_dialog); // for xr_meet logic, add dialog at the beginning of array
+    virtual void SetDefaultStartDialog(const DIALOG_ID_VECTOR& phrase_dialog);
+    virtual const DIALOG_ID_VECTOR& GetStartDialog() { return m_sStartDialog; }
     virtual void RestoreDefaultStartDialog();
 
 protected:
     //диалог, если не NULL, то его персонаж запустит
     //при встрече с актером
-    shared_str m_sStartDialog;
-    shared_str m_sDefaultStartDialog;
+    DIALOG_ID_VECTOR m_sStartDialog;
+    DIALOG_ID_VECTOR m_sDefaultStartDialog;
 
     using DIALOG_SHARED_VECTOR = xr_vector<DIALOG_SHARED_PTR>;
     //список диалогов, на которые нужно ответить

--- a/src/xrGame/ai/stalker/ai_stalker.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker.cpp
@@ -796,7 +796,11 @@ void CAI_Stalker::net_Export(NET_Packet& P)
         P.w(&f1, sizeof(f1));
     }
 
-    P.w_stringZ(m_sStartDialog);
+    P.w_u16(m_sStartDialog.size());
+    for (auto& Dialog : m_sStartDialog)
+    {
+        P.w_stringZ(Dialog);
+    }
 }
 
 void CAI_Stalker::net_Import(NET_Packet& P)
@@ -839,7 +843,14 @@ void CAI_Stalker::net_Import(NET_Packet& P)
     P.r_float();
     P.r_float();
 
-    P.r_stringZ(m_sStartDialog);
+    u16 DialogsNum = P.r_u16();
+    m_sStartDialog.clear();
+    for (u16 i = 0; i < DialogsNum; ++i)
+    {
+        shared_str DialogName;
+        P.r_stringZ(DialogName);
+        m_sStartDialog.push_back(DialogName);
+    }
 
     setVisible(TRUE);
     setEnabled(TRUE);

--- a/src/xrGame/script_game_object2.cpp
+++ b/src/xrGame/script_game_object2.cpp
@@ -330,7 +330,7 @@ void CScriptGameObject::GetStartDialog()
     CAI_PhraseDialogManager* pDialogManager = smart_cast<CAI_PhraseDialogManager*>(&object());
     if (!pDialogManager)
         return;
-    pDialogManager->GetStartDialog();
+    pDialogManager->GetStartDialog(); // TODO: Don't forget, this returns an array of start dialogs!
 }
 void CScriptGameObject::RestoreDefaultStartDialog()
 {

--- a/src/xrServerEntities/character_info.cpp
+++ b/src/xrServerEntities/character_info.cpp
@@ -33,7 +33,7 @@ CCharacterInfo::CCharacterInfo()
 #ifdef XRGAME_EXPORTS
     m_CurrentRank.set(NO_RANK);
     m_CurrentReputation.set(NO_REPUTATION);
-    m_StartDialog = NULL;
+    m_StartDialog.clear();
     m_Sympathy = 0.0f;
 #endif
 }
@@ -75,7 +75,7 @@ void CCharacterInfo::InitSpecificCharacter(shared_str new_id)
     }
     if (Community().index() == NO_COMMUNITY_INDEX)
         SetCommunity(m_SpecificCharacter.Community().index());
-    if (!m_StartDialog || !m_StartDialog.size())
+    if (!m_StartDialog.size())
         m_StartDialog = m_SpecificCharacter.data()->m_StartDialog;
 }
 
@@ -174,15 +174,35 @@ const shared_str& CCharacterInfo::IconName() const
     return m_SpecificCharacter.IconName();
 }
 
-shared_str CCharacterInfo::StartDialog() const { return m_StartDialog; }
+const DIALOG_ID_VECTOR& CCharacterInfo::StartDialog() const
+{
+    return m_StartDialog;
+}
 const DIALOG_ID_VECTOR& CCharacterInfo::ActorDialogs() const
 {
     R_ASSERT(m_SpecificCharacterId.size());
     return m_SpecificCharacter.data()->m_ActorDialogs;
 }
 
-void CCharacterInfo::load(IReader& stream) { stream.r_stringZ(m_StartDialog); }
-void CCharacterInfo::save(NET_Packet& stream) { stream.w_stringZ(m_StartDialog); }
+void CCharacterInfo::load(IReader& stream)
+{
+    u16 DialogsNum = stream.r_u16();
+    m_StartDialog.clear();
+    for (u16 i = 0; i < DialogsNum; ++i)
+    {
+        shared_str DialogName;
+        stream.r_stringZ(DialogName);
+        m_StartDialog.push_back(DialogName);
+    }
+}
+void CCharacterInfo::save(NET_Packet& stream)
+{
+    stream.w_u16(m_StartDialog.size());
+    for (auto& Dialog : m_StartDialog)
+    {
+        stream.w_stringZ(Dialog);
+    }
+}
 #endif
 
 void CCharacterInfo::InitXmlIdToIndex()

--- a/src/xrServerEntities/character_info.h
+++ b/src/xrServerEntities/character_info.h
@@ -96,7 +96,7 @@ protected:
     shared_str m_SpecificCharacterId;
 
 #ifdef XRGAME_EXPORTS
-    shared_str m_StartDialog;
+    DIALOG_ID_VECTOR m_StartDialog;
 
     //загруженная информация о конкретном персонаже
     CSpecificCharacter m_SpecificCharacter;
@@ -122,7 +122,7 @@ protected:
 public:
     const shared_str& IconName() const;
 
-    shared_str StartDialog() const;
+    const DIALOG_ID_VECTOR& StartDialog() const;
     const DIALOG_ID_VECTOR& ActorDialogs() const;
 #endif
 

--- a/src/xrServerEntities/specific_character.cpp
+++ b/src/xrServerEntities/specific_character.cpp
@@ -13,7 +13,7 @@ SSpecificCharacterData::SSpecificCharacterData()
     m_sSupplySpawn.clear();
     m_sNpcConfigSect.clear();
 
-    m_StartDialog = NULL;
+    m_StartDialog.clear();
     m_ActorDialogs.clear();
 
     m_Rank = NO_RANK;
@@ -91,15 +91,15 @@ void CSpecificCharacter::load_shared(LPCSTR)
 
 #ifdef XRGAME_EXPORTS
 
-    LPCSTR start_dialog = pXML->Read("start_dialog", 0, NULL);
-    if (start_dialog)
+    data()->m_StartDialog.clear();
+    int dialogs_num = pXML->GetNodesNum(pXML->GetLocalRoot(), "start_dialog");
+    for (int i = 0; i < dialogs_num; ++i)
     {
-        data()->m_StartDialog = start_dialog;
+        shared_str dialog_name = pXML->Read(pXML->GetLocalRoot(), "start_dialog", i, "");
+        data()->m_StartDialog.push_back(dialog_name);
     }
-    else
-        data()->m_StartDialog = NULL;
 
-    int dialogs_num = pXML->GetNodesNum(pXML->GetLocalRoot(), "actor_dialog");
+    dialogs_num = pXML->GetNodesNum(pXML->GetLocalRoot(), "actor_dialog");
     data()->m_ActorDialogs.clear();
     for (int i = 0; i < dialogs_num; ++i)
     {

--- a/src/xrServerEntities/specific_character.h
+++ b/src/xrServerEntities/specific_character.h
@@ -52,7 +52,7 @@ struct SSpecificCharacterData : CSharedResource
 #ifdef XRGAME_EXPORTS
 
     //начальный диалог
-    shared_str m_StartDialog;
+    DIALOG_ID_VECTOR m_StartDialog;
     //диалоги актера, которые будут доступны только при встрече с данным персонажем
     DIALOG_ID_VECTOR m_ActorDialogs;
 

--- a/src/xrServerEntities/xrServer_Objects_ALife_Monsters.cpp
+++ b/src/xrServerEntities/xrServer_Objects_ALife_Monsters.cpp
@@ -1821,7 +1821,7 @@ CSE_ALifeHumanStalker::CSE_ALifeHumanStalker(LPCSTR caSection)
     : CSE_ALifeHumanAbstract(caSection), CSE_PHSkeleton(caSection)
 {
     m_trader_flags.set(eTraderFlagInfiniteAmmo, true);
-    m_start_dialog = "";
+    m_start_dialog.clear();
 }
 
 CSE_ALifeHumanStalker::~CSE_ALifeHumanStalker() {}
@@ -1846,14 +1846,26 @@ void CSE_ALifeHumanStalker::UPDATE_Write(NET_Packet& tNetPacket)
 {
     inherited1::UPDATE_Write(tNetPacket);
     inherited2::UPDATE_Write(tNetPacket);
-    tNetPacket.w_stringZ(m_start_dialog);
+    tNetPacket.w_u16(m_start_dialog.size());
+    for (auto& Dialog : m_start_dialog)
+    {
+        tNetPacket.w_stringZ(Dialog);
+    }
 }
 
 void CSE_ALifeHumanStalker::UPDATE_Read(NET_Packet& tNetPacket)
 {
     inherited1::UPDATE_Read(tNetPacket);
     inherited2::UPDATE_Read(tNetPacket);
-    tNetPacket.r_stringZ(m_start_dialog);
+    u16 DialogsNum;
+    m_start_dialog.clear();
+    tNetPacket.r_u16(DialogsNum);
+    for (u16 i = 0; i < DialogsNum; ++i)
+    {
+        shared_str Dialog;
+        tNetPacket.r_stringZ(Dialog);
+        m_start_dialog.push_back(Dialog);
+    }
 }
 
 void CSE_ALifeHumanStalker::load(NET_Packet& tNetPacket)

--- a/src/xrServerEntities/xrServer_Objects_ALife_Monsters.h
+++ b/src/xrServerEntities/xrServer_Objects_ALife_Monsters.h
@@ -640,7 +640,7 @@ class CSE_ALifeHumanStalker : public CSE_ALifeHumanAbstract, public CSE_PHSkelet
     using inherited2 = CSE_PHSkeleton;
 
 public:
-    shared_str m_start_dialog;
+    DIALOG_ID_VECTOR m_start_dialog;
 
     CSE_ALifeHumanStalker(LPCSTR caSection);
     virtual ~CSE_ALifeHumanStalker();


### PR DESCRIPTION
Теперь если в character_desc_... .xml у НПС прописано несколько стартовых диалогов (ключ start_dialog), то они все будут читаться, а не только первый.
Таким образом, если прописано несколько start_dialog у НПС, то будет проведена проверка появления диалогов начиная с самого верхнего, и появится первый прошедший проверку диалог, либо диалог по умолчанию.
Так как тип переменной, хранящий стартовый диалог изменена с shared_str на вектор, также изменён принцип работы экспортированной Lua функции set_start_dialog: назначаемый диалог добавляется в самое начало вектора, таким образом он будет проверяться в первую очередь.